### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/mobileBlocks/MovingBlockComponent.java
+++ b/src/main/java/org/terasology/mobileBlocks/MovingBlockComponent.java
@@ -11,11 +11,11 @@ import org.terasology.gestalt.entitysystem.component.Component;
 @Replicate
 @ForceBlockActive
 public class MovingBlockComponent implements Component<MovingBlockComponent> {
-    private Block blockToRender;
-    private Vector3i locationFrom;
-    private Vector3i locationTo;
-    private long timeStart;
-    private long timeEnd;
+    public Block blockToRender;
+    public Vector3i locationFrom;
+    public Vector3i locationTo;
+    public long timeStart;
+    public long timeEnd;
 
     public MovingBlockComponent() {
     }


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191